### PR TITLE
Generating title of the conversation based on user message.

### DIFF
--- a/backend/openrouter.ts
+++ b/backend/openrouter.ts
@@ -83,3 +83,40 @@ export const createCompletion = async (messages: Message[],
     })
 }
 
+export async function generateTitleFromUserMessage({
+  message,
+}: {
+  message: string;
+}) {
+  const systemPrompt = `\n
+    - you will generate a short title based on the first message a user begins a conversation with
+    - ensure it is not more than 80 characters long
+    - the title should be a summary of the user's message
+    - do not use quotes or colons`;
+
+  const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${OPENROUTER_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: 'openai/gpt-4o-mini',
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: message },
+      ],
+      stream: false,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to generate title');
+  }
+
+  const data = await response.json();
+  const title = data.choices?.[0]?.message?.content?.trim() || '';
+  return title;
+}
+
+

--- a/backend/openrouter.ts
+++ b/backend/openrouter.ts
@@ -111,7 +111,7 @@ export async function generateTitleFromUserMessage({
   });
 
   if (!response.ok) {
-    throw new Error('Failed to generate title');
+    return message.slice(0, 20) + "...";
   }
 
   const data = await response.json();

--- a/backend/routes/ai.ts
+++ b/backend/routes/ai.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { CreateChatSchema, Role } from "../types";
-import { createCompletion } from "../openrouter";
+import { createCompletion, generateTitleFromUserMessage } from "../openrouter";
 import { InMemoryStore } from "../InMemoryStore";
 import { authMiddleware } from "../auth-middleware";
 import { PrismaClient } from "../generated/prisma";
@@ -103,9 +103,10 @@ router.post("/chat", authMiddleware, async (req, res) => {
     })
 
     if (!data.conversationId) {
+        const title = await generateTitleFromUserMessage(data.message);
         await prismaClient.conversation.create({
             data: {
-                title: data.message.slice(0, 20) + "...",
+                title,
                 id: conversationId,
                 userId,
             }


### PR DESCRIPTION
Added a new `generateTitleFromUserMessage` function in `openrouter.ts` that sends the user's first message to the OpenRouter API (using the `openai/gpt-4o-mini` model) to generate a short, relevant title, falling back to the previous truncation method if the API call fails.

Updated the conversation creation logic in `ai.ts` to use the new AI-generated title instead of a truncated message when starting a new conversation.
