### PR TITLE
Fix/rate limit correct window

### DIFF
--- a/backend/ratelimitter.ts
+++ b/backend/ratelimitter.ts
@@ -1,3 +1,4 @@
+
 import rateLimit from "express-rate-limit";
 
 // per-minute limiter

--- a/backend/ratelimitter.ts
+++ b/backend/ratelimitter.ts
@@ -1,4 +1,3 @@
-
 import rateLimit from "express-rate-limit";
 
 // per-minute limiter
@@ -9,8 +8,8 @@ export const perMinuteLimiter = rateLimit({
 });
 
 // per-hour limiter
-export const perMinuteLimiterRelaxed = rateLimit({
-  windowMs: 60 *  1000, // 1 hour
+export const perHourLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000, // 1 hour
   max: 5,
   message: "Too many requests. Try again in an hour.",
 });

--- a/backend/routes/auth.ts
+++ b/backend/routes/auth.ts
@@ -6,7 +6,7 @@ import { TOTP } from "totp-generator"
 import base32 from "hi-base32";
 import { PrismaClient } from "../generated/prisma";
 import { authMiddleware } from "../auth-middleware";
-import { perMinuteLimiter, perMinuteLimiterRelaxed } from "../ratelimitter";
+import { perMinuteLimiter, perHourLimiter } from "../ratelimitter";
 
 const prismaClient = new PrismaClient();
 
@@ -60,7 +60,7 @@ router.post("/initiate_signin", perMinuteLimiter, async (req, res) => {
     }
 })
 
-router.post("/signin", perMinuteLimiterRelaxed, async (req, res) => {
+router.post("/signin", perHourLimiter, async (req, res) => {
     const { success, data } = SignIn.safeParse(req.body);
 
     if (!success) {


### PR DESCRIPTION
Fixes a bug where the hourly rate limiter was using an incorrect time window. Updated it to properly enforce a 1-hour (3600s) limit. 