### PR TITLE
Add custom toast styling and update Toaster component options

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -62,7 +62,9 @@ export default function RootLayout({
             <FontProvider>
               <BlurProvider>
                 {children}
-                <Toaster />
+                <Toaster 
+                toastOptions={{className: 'sonner-toast'}} 
+                />
               </BlurProvider>
             </FontProvider>
         </ThemeProvider>

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -24,6 +24,12 @@ body {
   font-weight: 300;
 }
 
+.sonner-toast {
+  background: #f0b100 !important;
+  color: #fff !important;
+  border: #f0b100 !important;
+}
+
 .glass-card {
   @apply rounded-2xl border border-white/10 bg-white/5 backdrop-blur-md;
 }


### PR DESCRIPTION
Added custom styling to toast and toaster from sonner to match the theme and colour scheme of the other components

<img width="471" height="91" alt="Screenshot 2025-08-23 004359" src="https://github.com/user-attachments/assets/6aeed620-a2a0-4a88-9528-f34e18c4254b" />

<img width="472" height="105" alt="Screenshot 2025-08-23 004346" src="https://github.com/user-attachments/assets/f01eebe0-d444-4eac-a4d4-6d2a1cfad717" />

<img width="464" height="84" alt="Screenshot 2025-08-23 004132" src="https://github.com/user-attachments/assets/d0bd980d-6d60-4d95-9dcd-2a84fcf32c95" />
