### PR TITLE
fix: fixed conversation deletion added conversation delete route Fixes #74

### DIFF
--- a/backend/prisma/migrations/20250823180226_fix_cascade_delete_relation/migration.sql
+++ b/backend/prisma/migrations/20250823180226_fix_cascade_delete_relation/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "public"."Message" DROP CONSTRAINT "Message_conversationId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "public"."Message" ADD CONSTRAINT "Message_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "public"."Conversation"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -34,7 +34,7 @@ model Conversation {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   user      User     @relation(fields: [userId], references: [id])
-  messages  Message[]
+  messages  Message[] 
 }
 
 model Message {
@@ -44,7 +44,7 @@ model Message {
   role String
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-  conversation Conversation @relation(fields: [conversationId], references: [id])
+  conversation Conversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
 }
 
 model PaymentHistory {

--- a/backend/routes/ai.ts
+++ b/backend/routes/ai.ts
@@ -230,4 +230,35 @@ router.get("/credits", authMiddleware, async (req, res) => {
     }
 });
 
+// Delete old messages
+router.delete("/chat/:chatId", authMiddleware, async (req, res) => {
+    const userId = req.userId;
+    const chatId = req.params.chatId;
+    console.log("Deleting chat:", chatId, "for user:", userId);
+
+    try {
+        const deleteResult = await prismaClient.conversation.deleteMany({
+            where: {
+                id: chatId,
+                userId: userId
+            }
+        })
+
+        if (deleteResult.count === 0) {
+            return res.status(404).json({
+                message: "Chat not found"
+            });
+        }
+
+        res.status(200).json({
+            message: "Chat deleted successfully"
+        });
+    } catch (error) {
+        console.error("Error deleting chat:", error);
+        res.status(500).json({
+            message: "Internal server error"
+        });
+    }
+})
+
 export default router;

--- a/frontend/lib/chat-service.ts
+++ b/frontend/lib/chat-service.ts
@@ -229,4 +229,35 @@ export class ChatService {
       return null;
     }
   }
+
+  /**
+   * Delete a conversation
+   */
+  static async deleteConversation(conversationId: string): Promise<boolean> {
+    const token = this.getAuthToken();
+    console.log("conversation id in the frontend",conversationId)
+    if (!token) {
+      throw new Error("Authentication token not found. Please login again.");
+    }
+
+    try {
+      const response = await fetch(`${BACKEND_URL}/ai/chat/${conversationId}`, {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${token}`
+        }
+      });
+      console.log(response);
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      return true;
+    } catch (error) {
+      console.error("Error deleting conversation:", error);
+      return false;
+    }
+  }
 }


### PR DESCRIPTION
Fixed frontend: When a user deletes a conversation, they are redirected to /ask.
Added backend: route to handle conversation deletion 


after:

https://github.com/user-attachments/assets/22e96aa5-bfb8-40a6-b2bb-19fcea92969e

before:

https://github.com/user-attachments/assets/d4def62f-875d-40bd-8ae5-8550f6098a5c



Fixes #74 