### PR TITLE
Added auto focus to textarea on global keypress

### DIFF
--- a/frontend/components/ui/ui-input.tsx
+++ b/frontend/components/ui/ui-input.tsx
@@ -100,35 +100,35 @@ const UIInput = ({
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      const target = event.target as HTMLElement;
       if (
-        target.tagName === "INPUT" ||
-        target.tagName === "TEXTAREA" ||
-        target.tagName === "SELECT" ||
-        target.isContentEditable
+        event.target instanceof HTMLInputElement ||
+        event.target instanceof HTMLTextAreaElement
       ) {
         return;
       }
 
-      if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) {
-        return;
-      }
-
       if (
-        /^(F\d+|Tab|Escape|Enter|Backspace|Delete|Arrow\w+|Page\w+|Home|End|Insert)$/.test(
-          event.key
-        )
+        event.ctrlKey ||
+        event.metaKey ||
+        event.altKey ||
+        event.key.startsWith("F") ||
+        ["Tab","Escape","Enter","Backspace","Delete","ArrowUp","ArrowDown","ArrowLeft","ArrowRight"].includes(event.key)
       ) {
         return;
       }
 
-      if (textareaRef.current && !textareaRef.current.disabled) {
+      if (event.key.length === 1 && textareaRef.current) {
         event.preventDefault();
         textareaRef.current.focus();
-        textareaRef.current.setSelectionRange(
-          textareaRef.current.value.length,
-          textareaRef.current.value.length
-        );
+
+        const currentValue = textareaRef.current.value;
+        textareaRef.current.value = currentValue + event.key;
+
+        const length = textareaRef.current.value.length;
+        textareaRef.current.setSelectionRange(length, length);
+
+        const inputEvent = new Event("input", { bubbles: true });
+        textareaRef.current.dispatchEvent(inputEvent);
       }
     };
 


### PR DESCRIPTION
### Implement global keyboard listener that automatically focuses the main textarea when user types anywhere on the page.

solves https://github.com/code100x/1ai/issues/108

Features:
- Focuses textarea when any printable character is typed
- Preserves existing behavior in form inputs (search, etc.)
- Ignores modifier keys (Ctrl, Alt, Meta) and special keys (F-keys, Tab, Escape, arrows)
- Positions cursor at end of existing text
- Improves UX by allowing users to start typing immediately without clicking


https://github.com/user-attachments/assets/a6e0cec1-8885-469e-b9ca-f55496b7b4b0

