### PR TITLE
Prevent multiple empty chats from being created on "New Chat" click with minimal code

### DIFF
--- a/frontend/components/ui/ui-structure.tsx
+++ b/frontend/components/ui/ui-structure.tsx
@@ -95,8 +95,22 @@ export function UIStructure() {
               <Button
                 onClick={(e) => {
                   e.preventDefault();
-                  const id = createNewExecution();
-                  router.push(`/ask/${id}`);
+
+                  // Check if there is an existing "unsaved" or "empty" execution
+                  let currentExecution = uiExecutions.find(
+                    (exe) => exe.title === "New Execution" || exe.messages.length === 0
+                  );
+
+                  // If no empty execution exists, create one
+                  if (!currentExecution) {
+                    const id = createNewExecution();
+                    currentExecution = executions.find((exe) => exe.id === id);
+                  }
+
+                  // Navigate to that execution
+                  if (currentExecution) {
+                    router.push(`/ask/${currentExecution.id}`);
+                  }
                 }}
                 variant="accent"
                 className="w-full"

--- a/frontend/hooks/useExecution.ts
+++ b/frontend/hooks/useExecution.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 
 
 export interface Execution {
+    messages: any;
     id: string;
     title: string;
     createdAt: string;


### PR DESCRIPTION
closes: #168 with minimal code

Currently, clicking the "New Chat" button creates a new execution every time, leading to multiple empty chats in the sidebar.

This PR updates the "New Chat" logic to:
- Reuse an existing empty/default chat if available.
- Only create a new execution if there is no empty chat already.

This prevents duplicate empty chats and improves user experience.