### PR TITLE
bugFix: search icon and plus icon now visible in mobile view

### DIFF
--- a/frontend/app/_components/sidebar-toggle.tsx
+++ b/frontend/app/_components/sidebar-toggle.tsx
@@ -41,7 +41,7 @@ export const SidebarToggle = () => {
         <DialogTrigger className="hover:bg-muted flex size-7 items-center justify-center rounded-lg">
           <MagnifyingGlassIcon
             weight="bold"
-            className={cn(open ? "invisible" : "flex", "size-4")}
+            className={cn(open ? "lg:invisible" : "flex", "size-4")}
           />
         </DialogTrigger>
         <DialogContent className="border-none p-0">
@@ -65,7 +65,7 @@ export const SidebarToggle = () => {
         href={"/ask"}
         className="hover:bg-muted flex size-7 items-center justify-center rounded-lg"
       >
-        <PlusIcon weight="bold" className={open ? "invisible" : "flex"} />
+        <PlusIcon weight="bold" className={open ? "lg:invisible" : "flex"} />
       </Link>
     </div>
   );


### PR DESCRIPTION
closes: #167 

This PR fixes the visibility of the search (MagnifyingGlassIcon) and plus (PlusIcon) buttons in the SidebarToggle component.
Previously, these icons were invisible on mobile screens when the sidebar was closed.
Now, they are visible on mobile and only hidden on large screens when the sidebar is open, ensuring consistent UX across devices.

<img width="354" height="692" alt="Screenshot 2025-08-27 163338" src="https://github.com/user-attachments/assets/31f79293-0c89-41e7-a99a-db3f8e1bd0fb" />
