### PR TITLE
bug fix: Share Chat button fixed

### DIFF
--- a/frontend/components/ui/ui-structure.tsx
+++ b/frontend/components/ui/ui-structure.tsx
@@ -147,7 +147,7 @@ export function UIStructure() {
                                 e.preventDefault();
                                 const shareLink =
                                   process.env.NEXT_PUBLIC_APP_URL +
-                                  `/chat/share/${execution.id}`;
+                                  `/ask/${execution.id}`;
                                 navigator.clipboard.writeText(shareLink);
                                 toast.success("Share link copied to clipboard");
                               }}


### PR DESCRIPTION
closes: #70 

share chat button via link fixed 
- changes '/chat/share' to '/ask'