### PR TITLE
bug gix: added baseURL works for dev. and prod. both environment

### DIFF
--- a/frontend/components/ui/ui-structure.tsx
+++ b/frontend/components/ui/ui-structure.tsx
@@ -174,9 +174,8 @@ export function UIStructure() {
                               className="flex items-center justify-center rounded-md"
                               onClick={(e) => {
                                 e.preventDefault();
-                                const shareLink =
-                                  process.env.NEXT_PUBLIC_APP_URL +
-                                  `/ask/${execution.id}`;
+                                const baseURL = process.env.NEXT_PUBLIC_APP_URL || window.location.origin;
+                                const shareLink = `${baseURL}/ask/${execution.id}`;
                                 navigator.clipboard.writeText(shareLink);
                                 toast.success("Share link copied to clipboard");
                               }}


### PR DESCRIPTION
closes: #186 

- added:
```bash
const baseURL = process.env.NEXT_PUBLIC_APP_URL || window.location.origin;
const shareLink = `${baseURL}/ask/${execution.id}`;
```
this will work in both dev. and prod. environment